### PR TITLE
Changes for CNS-4192 -- isDefined helper, basedir to '/templates'

### DIFF
--- a/process
+++ b/process
@@ -65,6 +65,9 @@ $compile_options = array(
             return;
         }
       },
+      'isDefined' => function ($x, $options) {
+        return $options[isset($x) ? 'fn' : 'inverse']();
+      }
   ),
     'fileext' => array('.hbs')
 );

--- a/process
+++ b/process
@@ -13,7 +13,7 @@ $opts = getopt('', $options);
 
 $compile_options = array(
     'flags' => LightnCandy::FLAG_STANDALONE | LightnCandy::FLAG_RUNTIMEPARTIAL | LightnCandy::FLAG_ELSE | LightnCandy::FLAG_INSTANCE | LightnCandy::FLAG_PARENT | LightnCandy::FLAG_WITH | LightnCandy::FLAG_THIS | LightnCandy::FLAG_SPVARS,
-    'basedir' => array(THEME . 'templates/listings'),
+    'basedir' => array(THEME . 'templates'),
     'helpers' => array(
         'addOne' => function ($value) {
             return intval($value) + 1;


### PR DESCRIPTION
These are the two changes required for CNS-4192.

- Changed the `basedir` (used for resolving partials) to `THEME . 'templates/`
- Added an `isDefined` block helper that makes use of `isset()` in PHP. The JS version in flagship-cutter checks strict equality to `null` and `undefined`. This is necessary because of the nature of `{{#if }}`: it fails for empty arrays.

### For the reviewer

If you'd like to test that these changes actually do what they say, as opposed to just eyeballing the changes, head to `/wp-base-theme` and

```bash
$ git fetch
$ git checkout CNS-4192
$ npm install --save BoomTownROI/gulp-packages#CNS-4192
$ gulp php
```

- [x] Ensure that you don't see any changes in our checked in gen'd PHP templates (`wp-base-theme/templates/listings/**/*.php` or `wp-base-theme/templates/modals/register/*.php`)
- [x] Ensure that when server-side loading a details page, the document sent from the server contains the school info partial (only usage of the `isDefined()` helper.

_I would say you could test this on its own, outside the context of flagship-cutter, but there's a lot of coupling between the two, such as hard-coded relative file paths, etc. Honestly I don't know why this is in a different repo, but then again we used to have different repos for each theme and plugin._

Don't worry about creating a new version after this is merged, too.